### PR TITLE
Fix dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: pip install --no-deps .
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - pip
   run:
     - python
-    - html5lib >=0.999,!=0.9999,!=0.99999,<0.99999999
+    - html5lib ==0.999|>=0.999999999,<1.0
     - six
 
 test:


### PR DESCRIPTION
The dependencies are mis-specifed resulting in unsatisfiable errors when trying to install pacakges depending on `bleach`.

The [`setup.py`](https://github.com/mozilla/bleach/blob/master/setup.py#L16-L21) specifies the deps as:
```python
install_requires = [
    'six',
    # >= 8 9s because of breaking API change
    # the 'pre' suffix is needed for supporting '1.0b*' versions
    'html5lib>=0.99999999pre,!=1.0b1,!=1.0b2,!=1.0b3,!=1.0b4,!=1.0b5,!=1.0b6,!=1.0b7,!=1.0b8',
]
```

My reading of that is that any pre-release or released version of `0.99999999` is valid - i.e. all the following are valid `0.99999999a1`, `0.99999999b1`, `0.99999999rc1` and in particular `0.99999999` *is* valid.

The current `meta.yaml` specifies `<0.99999999` which I believe is incorrect.

My understanding of the intent of the byzantine version specifications is that 1.0 introduced a breaking change so isn't acceptable, nor are any 1.0 pre-releases. `0.999` is ok, but no later versions until `0.999999999` will work.

The changes in this PR should hopefully reflect that intent and importantly will allow `0.999999999`