### PR TITLE
Bump build # to trigger a rebuild with conda-build 3.17. Fixes #17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 48d39675b80a75f6d1c3bdbffec791cf0bbbab665cf01e20da701c77de278718
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vvv"
 


### PR DESCRIPTION
Just bumps build number, so we can get the package rebuilt with conda-build 3.17. See #17 for discussion.